### PR TITLE
Fix the color bug on Safari.

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@ d3.csv("names.csv", function(error, names) {
   //     });
   // }
 	for (var i=0, iLen=nodes.length; i<iLen; i++) {
-		n = nodes[i].lastChild.innerHTML;
+		n = nodes[i].lastChild.textContent;
 		c = nodes[i].firstChild;
     names.forEach(function(names) {
     	console.log(names.name);


### PR DESCRIPTION
fixed the bug of circle's className, Safari's innerHTML missing problem on SVG element.

https://bugs.webkit.org/show_bug.cgi?id=136903

``` javascript
// Alternative:
nodes[i].lastChild.childNodes[0].wholeText;
```

http://houkanshan.github.io/genealogy/
